### PR TITLE
Deliver Twice Bug Fix

### DIFF
--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -625,7 +625,7 @@ func (c *Controller) sync() (viewNum uint64, seq uint64, decisions uint64) {
 
 	latestSequence := c.latestSeq()
 
-	if md.LatestSequence >= latestSequence {
+	if md.LatestSequence > latestSequence {
 		c.Logger.Infof("Synchronizer returned with sequence %d while the controller is at sequence %d", md.LatestSequence, latestSequence)
 		c.Logger.Debugf("Node %d is setting the checkpoint after sync returned with view %d and seq %d", c.ID, md.ViewId, md.LatestSequence)
 		c.Checkpoint.Set(decision.Proposal, decision.Signatures)

--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -593,7 +593,7 @@ func (c *Controller) sync() (viewNum uint64, seq uint64, decisions uint64) {
 	}
 
 	// The synchronizer returns a response which includes the latest decision with its proposal metadata.
-	// This proposal may be empty (its metadata is nil), meaning the synchronizer is not aware of any decisions made.
+	// This proposal may be empty (its metadata is empty), meaning the synchronizer is not aware of any decisions made.
 	// Otherwise, the latest proposal sequence returned may be higher than our latest sequence, meaning we should
 	// update the checkpoint.
 	// In other cases we should not update the checkpoint.
@@ -605,8 +605,8 @@ func (c *Controller) sync() (viewNum uint64, seq uint64, decisions uint64) {
 	latestDecision := syncResponse.Latest
 	var latestDecisionSeq, latestDecisionViewNum, latestDecisionDecisions uint64
 	var latestDecisionMetadata *protos.ViewMetadata
-	if latestDecision.Proposal.Metadata == nil {
-		c.Logger.Infof("Synchronizer returned with proposal metadata nil")
+	if len(latestDecision.Proposal.Metadata) == 0 {
+		c.Logger.Infof("Synchronizer returned with an empty proposal metadata")
 		latestDecisionMetadata = nil
 	} else {
 		md := &protos.ViewMetadata{}

--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -625,6 +625,13 @@ func (c *Controller) sync() (viewNum uint64, seq uint64, decisions uint64) {
 
 	latestSequence := c.latestSeq()
 
+	if md.LatestSequence >= latestSequence {
+		c.Logger.Infof("Synchronizer returned with sequence %d while the controller is at sequence %d", md.LatestSequence, latestSequence)
+		c.Logger.Debugf("Node %d is setting the checkpoint after sync returned with view %d and seq %d", c.ID, md.ViewId, md.LatestSequence)
+		c.Checkpoint.Set(decision.Proposal, decision.Signatures)
+		c.verificationSequence = uint64(decision.Proposal.VerificationSequence)
+	}
+
 	if md.ViewId < c.currViewNumber {
 		c.Logger.Infof("Synchronizer returned with view number %d but the controller is at view number %d", md.ViewId, c.currViewNumber)
 		response := c.fetchState()
@@ -681,11 +688,9 @@ func (c *Controller) sync() (viewNum uint64, seq uint64, decisions uint64) {
 		}
 	}
 
-	c.Logger.Debugf("Node %d is setting the checkpoint after sync to view %d and seq %d", c.ID, md.ViewId, md.LatestSequence)
-	c.Checkpoint.Set(decision.Proposal, decision.Signatures)
-	c.verificationSequence = uint64(decision.Proposal.VerificationSequence)
 	c.Logger.Debugf("Node %d is informing the view changer after sync of view %d and seq %d", c.ID, md.ViewId, md.LatestSequence)
 	c.ViewChanger.InformNewView(view)
+
 	if md.LatestSequence == 0 || newView {
 		return view, md.LatestSequence + 1, 0
 	}

--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -1430,6 +1430,7 @@ func TestDeliverTwiceOnceFromSyncAndOnceFromViewData(t *testing.T) {
 
 	synchronizerWG.Add(1)
 	commSendWG.Add(6) // fetch and send state after sync
+	leaderMonWG.Add(1)
 	ticker <- startTime.Add(5 * time.Second)
 	ticker <- startTime.Add(10 * time.Second)
 	ticker <- startTime.Add(9 * time.Second)
@@ -1439,6 +1440,7 @@ func TestDeliverTwiceOnceFromSyncAndOnceFromViewData(t *testing.T) {
 	ticker <- startTime.Add(25 * time.Second) // view change timeout (with backoff)
 	synchronizerWG.Wait()
 	commSendWG.Wait()
+	leaderMonWG.Wait() // change view after sync returns
 	synchronizer.AssertNumberOfCalls(t, "Sync", 2)
 
 	// The view change continues

--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -1178,3 +1178,354 @@ func TestRotateFromFollowerToLeader(t *testing.T) {
 
 	controller.Stop()
 }
+
+func TestDeliverTwiceOnceFromSyncAndOnceFromViewData(t *testing.T) {
+
+	// TODO add comments
+
+	basicLog, err := zap.NewDevelopment()
+	assert.NoError(t, err)
+	log := basicLog.Sugar()
+
+	testDir, err := os.MkdirTemp("", "controller-unittest")
+	assert.NoErrorf(t, err, "generate temporary test dir")
+	defer os.RemoveAll(testDir)
+	wal, err := wal.Create(log, testDir, nil)
+	assert.NoError(t, err)
+
+	comm := &mocks.CommMock{}
+	comm.On("BroadcastConsensus", mock.Anything)
+	commSendWG := sync.WaitGroup{}
+	comm.On("SendConsensus", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		commSendWG.Done()
+	})
+	reqTimer := &mocks.RequestsTimer{}
+	reqTimer.On("StopTimers")
+	reqTimer.On("RestartTimers")
+
+	ticker := make(chan time.Time)
+
+	signer := &mocks.SignerMock{}
+	signer.On("Sign", mock.Anything).Return(nil)
+	signer.On("SignProposal", mock.Anything, mock.Anything).Return(&types.Signature{
+		ID:    4,
+		Value: []byte{4},
+	})
+
+	batcher := &mocks.Batcher{}
+	batcher.On("Close")
+
+	state := &mocks.State{}
+	state.On("Save", mock.Anything).Return(nil)
+
+	verifier := &mocks.VerifierMock{}
+	verifier.On("VerificationSequence").Return(uint64(1))
+	verifierSigWG := sync.WaitGroup{}
+	verifier.On("VerifySignature", mock.Anything).Run(func(args mock.Arguments) {
+		verifierSigWG.Done()
+	}).Return(nil)
+	verifier.On("VerifyConsenterSig", mock.Anything, mock.Anything).Return(bft.MarshalOrPanic(&protos.PreparesFrom{
+		Ids: []uint64{1},
+	}), nil)
+	verifier.On("VerifyProposal", mock.Anything, mock.Anything).Return(nil, nil)
+
+	assembler := &mocks.AssemblerMock{}
+
+	reqPool := &mocks.RequestPool{}
+	reqPool.On("Close")
+
+	leaderMon := &mocks.LeaderMonitor{}
+	leaderMonWG := sync.WaitGroup{}
+	leaderMon.On("ChangeRole", bft.Follower, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		leaderMonWG.Done()
+	})
+	leaderMon.On("InjectArtificialHeartbeat", uint64(1), mock.Anything)
+	leaderMon.On("Close")
+
+	synchronizer := &mocks.SynchronizerMock{}
+	synchronizerWG := sync.WaitGroup{}
+	synchronizer.On("Sync").Run(func(args mock.Arguments) {
+		synchronizerWG.Done()
+	}).Return(types.SyncResponse{Latest: types.Decision{
+		Proposal: types.Proposal{
+			Metadata: bft.MarshalOrPanic(&protos.ViewMetadata{
+				LatestSequence: 0,
+				ViewId:         0,
+			}),
+			VerificationSequence: 1,
+		},
+		Signatures: []types.Signature{
+			{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5},
+		},
+	}, Reconfig: types.ReconfigSync{InReplicatedDecisions: false}}).Once()
+	synchronizer.On("Sync").Run(func(args mock.Arguments) {
+		synchronizerWG.Done()
+	}).Return(types.SyncResponse{Latest: types.Decision{
+		Proposal: types.Proposal{
+			Metadata: bft.MarshalOrPanic(&protos.ViewMetadata{
+				LatestSequence: 1,
+				ViewId:         0,
+			}),
+			VerificationSequence: 1,
+		},
+		Signatures: []types.Signature{
+			{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5},
+		},
+	}, Reconfig: types.ReconfigSync{InReplicatedDecisions: false}}).Once()
+
+	collector := bft.StateCollector{
+		SelfID:         4,
+		N:              7,
+		Logger:         log,
+		CollectTimeout: 100 * time.Millisecond,
+	}
+	collector.Start()
+
+	app := &mocks.ApplicationMock{}
+	app.On("Deliver", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		proposal := args.Get(0).(types.Proposal)
+		md := &protos.ViewMetadata{}
+		if err := proto.Unmarshal(proposal.Metadata, md); err != nil {
+			panic("Error unmarshaling metadata")
+		}
+		if md.LatestSequence == 1 {
+			panic("Delivering sequence 1 twice")
+		}
+	}).Return(types.Reconfig{InLatestDecision: false})
+
+	vc := &bft.ViewChanger{
+		SelfID:            4,
+		N:                 7,
+		NodesList:         []uint64{1, 2, 3, 4, 5, 6, 7},
+		Logger:            log,
+		Comm:              comm,
+		Application:       app,
+		Verifier:          verifier,
+		Signer:            signer,
+		RequestsTimer:     reqTimer,
+		State:             state,
+		InFlight:          &bft.InFlightData{},
+		Ticker:            ticker,
+		InMsqQSize:        100,
+		MetricsViewChange: api.NewMetricsViewChange(&disabled.Provider{}),
+		ViewChangeTimeout: 10 * time.Second,
+		ResendTimeout:     20 * time.Second,
+	}
+
+	vc.ControllerStartedWG.Add(1)
+
+	controller := &bft.Controller{
+		InFlight:      &bft.InFlightData{},
+		Signer:        signer,
+		State:         state,
+		WAL:           wal,
+		ID:            4,
+		N:             7,
+		NodesList:     []uint64{1, 2, 3, 4, 5, 6, 7},
+		Logger:        log,
+		Batcher:       batcher,
+		Verifier:      verifier,
+		Assembler:     assembler,
+		Comm:          comm,
+		RequestPool:   reqPool,
+		LeaderMonitor: leaderMon,
+		Synchronizer:  synchronizer,
+		ViewChanger:   vc,
+		Checkpoint:    &types.Checkpoint{},
+		Collector:     &collector,
+		StartedWG:     &vc.ControllerStartedWG,
+	}
+	configureProposerBuilder(controller)
+
+	controller.Checkpoint.Set(proposal, []types.Signature{{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5}})
+
+	vc.Controller = controller
+	vc.Synchronizer = controller
+	vc.Checkpoint = controller.Checkpoint
+	vc.Start(0)
+
+	vs := configureProposerBuilder(controller)
+	controller.ViewSequences = vs
+
+	leaderMonWG.Add(1)
+	controller.Start(0, 1, 0, false)
+	leaderMonWG.Wait()
+
+	startTime := time.Now()
+	vc.StartViewChange(1, true)
+
+	vc.HandleMessage(1, viewChangeMsg)
+	vc.HandleMessage(2, viewChangeMsg)
+	vc.HandleMessage(3, viewChangeMsg)
+	commSendWG.Add(1) // sending view data msg and joining the view change
+	vc.HandleMessage(5, viewChangeMsg)
+	commSendWG.Wait()
+
+	synchronizerWG.Add(1)
+	commSendWG.Add(6) // fetch and send state after sync
+	leaderMonWG.Add(1)
+	ticker <- startTime.Add(5 * time.Second)
+	ticker <- startTime.Add(10 * time.Second)
+	ticker <- startTime.Add(9 * time.Second)
+	ticker <- startTime.Add(12 * time.Second)
+	ticker <- startTime.Add(15 * time.Second) // view change timeout
+	synchronizerWG.Wait()
+	commSendWG.Wait()
+	synchronizer.AssertNumberOfCalls(t, "Sync", 1)
+	leaderMonWG.Wait()
+
+	commSendWG.Add(6) // send prepares
+	controller.ProcessMessages(1, prePrepareSeq1View0)
+	commSendWG.Wait()
+
+	commSendWG.Add(6) // send commits
+	controller.ProcessMessages(1, prepareSeq1View0)
+	controller.ProcessMessages(2, prepareSeq1View0)
+	controller.ProcessMessages(3, prepareSeq1View0)
+	controller.ProcessMessages(7, prepareSeq1View0)
+	commSendWG.Wait()
+
+	verifierSigWG.Add(5)
+	leaderMonWG.Add(1)
+	vc.HandleMessage(2, createNewViewMsgForDeliverTwiceTest(1))
+	verifierSigWG.Wait() // got the new view msg
+	leaderMonWG.Wait()   // changed view and created the view
+
+	startTime = time.Now()
+	vc.StartViewChange(2, true)
+
+	viewChangeMsg2 := proto.Clone(viewChangeMsg).(*protos.Message)
+	viewChangeMsg2.GetViewChange().NextView = 2
+	vc.HandleMessage(1, viewChangeMsg2)
+	vc.HandleMessage(2, viewChangeMsg2)
+	vc.HandleMessage(3, viewChangeMsg2)
+	commSendWG.Add(1) // sending view data msg and joining the view change
+	vc.HandleMessage(5, viewChangeMsg2)
+	commSendWG.Wait()
+
+	synchronizerWG.Add(1)
+	commSendWG.Add(6) // fetch and send state after sync
+	ticker <- startTime.Add(5 * time.Second)
+	ticker <- startTime.Add(10 * time.Second)
+	ticker <- startTime.Add(9 * time.Second)
+	ticker <- startTime.Add(12 * time.Second)
+	ticker <- startTime.Add(15 * time.Second)
+	ticker <- startTime.Add(20 * time.Second)
+	ticker <- startTime.Add(25 * time.Second) // view change timeout (with backoff)
+	synchronizerWG.Wait()
+	commSendWG.Wait()
+	synchronizer.AssertNumberOfCalls(t, "Sync", 2)
+
+	viewChangeMsg3 := proto.Clone(viewChangeMsg).(*protos.Message)
+	viewChangeMsg3.GetViewChange().NextView = 3
+	vc.HandleMessage(1, viewChangeMsg3)
+	vc.HandleMessage(2, viewChangeMsg3)
+	vc.HandleMessage(3, viewChangeMsg3)
+	vc.HandleMessage(5, viewChangeMsg3)
+
+	viewData := createViewDataForDeliverTwiceTest(3, 1)
+	vdBytes := bft.MarshalOrPanic(viewData)
+	viewDataMsg1 := &protos.Message{
+		Content: &protos.Message_ViewData{
+			ViewData: &protos.SignedViewData{
+				RawViewData: vdBytes,
+				Signer:      1,
+				Signature:   nil,
+			},
+		},
+	}
+	verifierSigWG.Add(1)
+	vc.HandleMessage(1, viewDataMsg1)
+	verifierSigWG.Wait()
+
+	controller.Stop()
+	vc.Stop()
+	collector.Stop()
+	wal.Close()
+}
+
+var (
+	prePrepareSeq1View0 = &protos.Message{
+		Content: &protos.Message_PrePrepare{
+			PrePrepare: &protos.PrePrepare{
+				View: 0,
+				Seq:  1,
+				Proposal: &protos.Proposal{
+					Header:  []byte{0},
+					Payload: []byte{1},
+					Metadata: bft.MarshalOrPanic(&protos.ViewMetadata{
+						LatestSequence: 1,
+						ViewId:         0,
+					}),
+					VerificationSequence: 1,
+				},
+			},
+		},
+	}
+	proposalSeq1View0 = &types.Proposal{
+		Header:  []byte{0},
+		Payload: []byte{1},
+		Metadata: bft.MarshalOrPanic(&protos.ViewMetadata{
+			LatestSequence: 1,
+			ViewId:         0,
+		}),
+		VerificationSequence: 1,
+	}
+	prepareSeq1View0 = &protos.Message{
+		Content: &protos.Message_Prepare{
+			Prepare: &protos.Prepare{
+				View:   0,
+				Seq:    1,
+				Digest: proposalSeq1View0.Digest(),
+			},
+		},
+	}
+)
+
+func createViewDataForDeliverTwiceTest(nextView, lastDecisionSequence uint64) *protos.ViewData {
+	lastDecision := types.Proposal{
+		Metadata: bft.MarshalOrPanic(&protos.ViewMetadata{
+			LatestSequence: lastDecisionSequence,
+			ViewId:         0,
+		}),
+		VerificationSequence: 1,
+	}
+	lastDecisionSignaturesProtos := []*protos.Signature{{Signer: 1, Value: []byte{4}, Msg: []byte{5}}, {Signer: 2, Value: []byte{4}, Msg: []byte{5}}, {Signer: 3, Value: []byte{4}, Msg: []byte{5}}, {Signer: 4, Value: []byte{4}, Msg: []byte{5}}, {Signer: 5, Value: []byte{4}, Msg: []byte{5}}}
+	return &protos.ViewData{
+		NextView: nextView,
+		LastDecision: &protos.Proposal{
+			Header:               lastDecision.Header,
+			Payload:              lastDecision.Payload,
+			Metadata:             lastDecision.Metadata,
+			VerificationSequence: uint64(lastDecision.VerificationSequence),
+		},
+		LastDecisionSignatures: lastDecisionSignaturesProtos,
+	}
+}
+
+func createNewViewMsgForDeliverTwiceTest(nextView uint64) *protos.Message {
+	q := 5
+	vd := createViewDataForDeliverTwiceTest(nextView, 0)
+	vdBytes := bft.MarshalOrPanic(vd)
+
+	signed := make([]*protos.SignedViewData, 0)
+	for len(signed) < q { // quorum
+		msg := &protos.Message{
+			Content: &protos.Message_ViewData{
+				ViewData: &protos.SignedViewData{
+					RawViewData: vdBytes,
+					Signer:      uint64(len(signed) + 1),
+					Signature:   nil,
+				},
+			},
+		}
+		signed = append(signed, msg.GetViewData())
+	}
+	return &protos.Message{
+		Content: &protos.Message_NewView{
+			NewView: &protos.NewView{
+				SignedViewData: signed,
+			},
+		},
+	}
+}

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -385,7 +385,7 @@ func (v *ViewChanger) startViewChange(change *change) {
 	v.Comm.BroadcastConsensus(msg)
 	v.Logger.Debugf("Node %d started view change, last view is %d", v.SelfID, v.currView)
 	if change.stopView {
-		v.Controller.AbortView(v.currView) // abort the current view when joining view change // TODO maybe abort before sending view data
+		v.Controller.AbortView(v.currView) // abort the current view when joining view change
 	}
 	v.startViewChangeTime = v.lastTick
 	v.checkTimeout = true
@@ -416,6 +416,7 @@ func (v *ViewChanger) processViewChangeMsg(restore bool) {
 			v.Logger.Panicf("Failed to save message to state, error: %v", err)
 		}
 	}
+	v.Controller.AbortView(v.currView) // before preparing the view data message abort the current view
 	v.currView = v.nextView
 	v.MetricsViewChange.CurrentView.Set(float64(v.currView))
 	v.viewChangeMsgs.clear(v.N)

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -385,7 +385,7 @@ func (v *ViewChanger) startViewChange(change *change) {
 	v.Comm.BroadcastConsensus(msg)
 	v.Logger.Debugf("Node %d started view change, last view is %d", v.SelfID, v.currView)
 	if change.stopView {
-		v.Controller.AbortView(v.currView) // abort the current view when joining view change
+		v.Controller.AbortView(v.currView) // abort the current view when joining view change // TODO maybe abort before sending view data
 	}
 	v.startViewChangeTime = v.lastTick
 	v.checkTimeout = true

--- a/internal/bft/viewchanger_test.go
+++ b/internal/bft/viewchanger_test.go
@@ -226,7 +226,7 @@ func TestViewChangeProcess(t *testing.T) {
 			comm.AssertCalled(t, "SendConsensus", uint64(2), mock.Anything)
 
 			reqTimer.AssertNumberOfCalls(t, "StopTimers", 2)
-			controller.AssertNumberOfCalls(t, "AbortView", 2)
+			controller.AssertNumberOfCalls(t, "AbortView", 4)
 			state.AssertNumberOfCalls(t, "Save", 2)
 
 			vc.Stop()
@@ -470,7 +470,7 @@ func TestNormalProcess(t *testing.T) {
 	num = <-seqNumChan
 	assert.Equal(t, uint64(2), num)
 
-	controller.AssertNumberOfCalls(t, "AbortView", 1)
+	controller.AssertNumberOfCalls(t, "AbortView", 2)
 	state.AssertNumberOfCalls(t, "Save", 2)
 
 	vc.Stop()
@@ -1216,7 +1216,7 @@ func TestCommitLastDecision(t *testing.T) {
 	num = <-seqNumChan
 	assert.Equal(t, uint64(3), num)
 
-	controller.AssertNumberOfCalls(t, "AbortView", 1)
+	controller.AssertNumberOfCalls(t, "AbortView", 2)
 	app.AssertNumberOfCalls(t, "Deliver", 1)
 	pruner.AssertNumberOfCalls(t, "MaybePruneRevokedRequests", 1)
 	state.AssertNumberOfCalls(t, "Save", 2)
@@ -1401,7 +1401,7 @@ func TestInFlightProposalInViewData(t *testing.T) {
 			vc.Stop()
 
 			reqTimer.AssertNumberOfCalls(t, "StopTimers", 1)
-			controller.AssertNumberOfCalls(t, "AbortView", 1)
+			controller.AssertNumberOfCalls(t, "AbortView", 2)
 			state.AssertNumberOfCalls(t, "Save", 1)
 		})
 	}
@@ -2042,7 +2042,7 @@ func TestCommitInFlight(t *testing.T) {
 	num = <-seqNumChan
 	assert.Equal(t, uint64(3), num)
 
-	controller.AssertNumberOfCalls(t, "AbortView", 1)
+	controller.AssertNumberOfCalls(t, "AbortView", 2)
 	pruner.AssertNumberOfCalls(t, "MaybePruneRevokedRequests", 1)
 
 	vc.Stop()

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1077,7 +1077,7 @@ func TestFollowerStateTransfer(t *testing.T) {
 	syncedWG.Add(1)
 	baseLogger6 := nodes[6].logger.Desugar()
 	nodes[6].logger = baseLogger6.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
-		if strings.Contains(entry.Message, "The collected state") {
+		if strings.Contains(entry.Message, "collected state") {
 			syncedWG.Done()
 		}
 		return nil
@@ -2747,7 +2747,7 @@ func TestFetchStateWhenSyncReturnsPrevView(t *testing.T) {
 				}
 			}
 
-			if strings.Contains(entry.Message, "Collected state with view 2 and sequence 2") {
+			if strings.Contains(entry.Message, "collected state with view 2 and sequence 2") {
 				stateWG.Done()
 			}
 

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -76,6 +76,9 @@ func TestNodeViewChangeWhileInPartition(t *testing.T) {
 	var viewChangeTimeoutWG sync.WaitGroup
 	viewChangeTimeoutWG.Add(1)
 
+	var viewChangeWG sync.WaitGroup
+	viewChangeWG.Add(1)
+
 	var syncWG sync.WaitGroup
 	syncWG.Add(1)
 
@@ -89,6 +92,10 @@ func TestNodeViewChangeWhileInPartition(t *testing.T) {
 
 		if strings.Contains(entry.Message, "Node 4 is setting the checkpoint after sync returned with view 0 and seq 1") {
 			syncWG.Done()
+		}
+
+		if strings.Contains(entry.Message, "ViewChanged, the new view is 1") {
+			viewChangeWG.Done()
 		}
 
 		return nil
@@ -134,6 +141,8 @@ func TestNodeViewChangeWhileInPartition(t *testing.T) {
 	syncWG.Wait()
 	// Ensure the last node successfully delivers the block to the application
 	<-nodes[len(nodes)-1].Delivered
+	// Make sure view change occurred
+	viewChangeWG.Wait()
 }
 
 func TestRestartFollowers(t *testing.T) {


### PR DESCRIPTION
In this scenario a decision is delivered twice.
Once by the synchronizer and a second time by the view data received during a view change.

The reason this is even possible is twofold.
First of all, after a view change timeout, we do not stop the running view (since a sync may created a good view), and so the view and the view change are running concurrently. It is feasible for a decision to be made during the concurrent view and a view change to occur while the new view message doesn't include that decision. That decision will be delivered to a node during a sync. Secondly, when the sync returns with the decision belonging to an old view we do not update the checkpoint. And so when there is another view change and a view data msg with that decision is received the node thinks this is a new decision (because its checkpoint was not updated). Finally, the node delivers that decision again from the view data msg (for the second time).

The fix includes an update of the checkpoint also when the synchronizer returns with an old view, and aborting a view before sending a view data msg to avoid running concurrent view and view change.